### PR TITLE
Make sql trigger func modular so they do not interfere with one another

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,7 +52,11 @@ func SetupWebhook(
 	}
 
 	// init the trigger function
-	db.CreateTrigger(ctx, dbPool, "audits")
+	db.CreateTrigger(ctx, dbPool, "audits", db.TriggerOptions{
+		UpdateEntityURL:     &updateEntityUrl,
+		NewSubmissionURL:    &newSubmissionUrl,
+		ReviewSubmissionURL: &reviewSubmissionUrl,
+	})
 
 	// setup the notifier
 	notifier := db.NewNotifier(log, listener)


### PR DESCRIPTION
Fixes https://github.com/hotosm/fmtm/issues/2569

Makes the SQL trigger function construction modular, only enabling the `CASE / WHEN` for each event, if they are specified in the webhook URLs.

Workaround to ensure trigger works for all entity updates and submission reviews, even if the submission XML is large (avoids running submission create trigger). Until #9 is fixed.

@renatocava this doesn't fix the issue for using the `submission.create` event, but it will prevent the webhook breaking if the submission XML is large and you are using `submission.update` or `entity.update` events, so it's a partial fix 👍 