### PR TITLE
fix: make submission.create send data with http_post direct on Trigger

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,15 @@ func SetupWebhook(
 
 				// Only send the request for correctly parsed (supported) events
 				if parsedData != nil {
+
+					if parsedData.HttpSent {
+						// This event was already sent via HTTP, just log for monitoring
+						log.Info("event was already sent via HTTP",
+							"eventType", parsedData.Type,
+							"truncated", parsedData.Truncated)
+						continue
+					}
+
 					if parsedData.Type == "entity.update.version" && updateEntityUrl != "" {
 						webhook.SendRequest(log, ctx, updateEntityUrl, *parsedData, apiKey)
 					} else if parsedData.Type == "submission.create" && newSubmissionUrl != "" {


### PR DESCRIPTION
- [x] I added http_post from the http extension and fixed the 8KB limit issue for submission.create - issue #9 
- [x] Condition into createFunctionSQL in trigger.go that prevent the dublicate logs when use newSubmissionUrl - issue #2 

<img width="1268" height="214" alt="image" src="https://github.com/user-attachments/assets/af896c87-d568-4450-9a3a-13b9abafff77" />



