### PR TITLE
Added missing 'install' flag in ENTRYPOINT and added local build for docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,4 @@ COPY --from=useradd /etc/group /etc/group
 COPY --from=useradd /etc/passwd /etc/passwd
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 USER nonroot:nonroot
-ENTRYPOINT ["/app/centralwebhook"]
+ENTRYPOINT ["/app/centralwebhook", "install"]

--- a/compose.webhook.yml
+++ b/compose.webhook.yml
@@ -12,13 +12,20 @@ services:
       timeout: 5s
       retries: 10
 
-  # Override the image used to contain the `pgsql-http` extension
+  # Override the image used to contain the `pgsql-http` extension and a healthcheck
   postgres14:
     image: "ghcr.io/hotosm/postgres:14-http"
 
+    healthcheck:
+      test: pg_isready -U ${DB_USER:-odk} || exit 1
+      start_period: 10s
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
   # The main webhook service
   webhook:
-    image: "ghcr.io/hotosm/central-webhook:0.2.0"
+    image: "ghcr.io/hotosm/central-webhook:1.0.2"
     environment:
       CENTRAL_WEBHOOK_DB_URI: postgresql://odk:odk@postgres14:5432/odk?sslmode=disable
       CENTRAL_WEBHOOK_UPDATE_ENTITY_URL: ${CENTRAL_WEBHOOK_UPDATE_ENTITY_URL}
@@ -26,9 +33,10 @@ services:
       CENTRAL_WEBHOOK_NEW_SUBMISSION_URL: ${CENTRAL_WEBHOOK_NEW_SUBMISSION_URL}
       CENTRAL_WEBHOOK_API_KEY: ${CENTRAL_WEBHOOK_API_KEY}
       CENTRAL_WEBHOOK_LOG_LEVEL: ${CENTRAL_WEBHOOK_LOG_LEVEL:-INFO}
+    # It waits for everything to be ready to install the trigger
     depends_on:
       postgres14:
-        condition: service_started
+        condition: service_healthy
       service:
-        condition: service_started
-    restart: always
+        condition: service_healthy
+    restart: on-failure


### PR DESCRIPTION
The call to the CLI in the docker container was missing the `install` flag. I added it and now the container creates the trigger succesfully by doing this `docker compose -f docker-compose.yml -f ../central-webhook/compose.webhook.yaml up -d`.

It also happened that `compose.webhook.yml` was fetching the docker image from the repo, so that I was not able to test changes to Dockerfile. So, instead of fetching the image from the repo I built the image from Dockerfile.

The thing is, by doing this

`docker compose -f docker-compose.yml -f ../central-webhook/compose.webhook.yaml up -d`

all paths are relative to the directory of the first compose file, see [this](https://github.com/docker/compose/issues/3874).  I thought that the simplest way to fix this was to create a new env variable `CENTRAL_WEBHOOK_PATH` to store the absolute path to `central-webhook` folder and use this env variable in `compose.webhook.yml`. This is okay for you?

---

Other things that happen is that this docker container is just creating the trigger and then doing nothing. It is also configured with `restart: always` so it keeps replacing the trigger and restarting to replace the trigger again.

Also, in the beggining, it fails to create the trigger, so the first few restarts are because of the healthcheck you added, I think. Here you have some logs.

### PostgreSQL:

```
waiting for server to start....2025-12-22 22:48:53.048 UTC [46] LOG:  starting PostgreSQL 14.20 (Debian 14.20-1.pgdg13+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit
2025-12-22 22:48:53.136 UTC [46] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-12-22 22:48:53.494 UTC [47] LOG:  database system was shut down at 2025-12-22 22:48:46 UTC
2025-12-22 22:48:53.645 UTC [46] LOG:  database system is ready to accept connections
 done
server started
CREATE DATABASE


/usr/local/bin/docker-entrypoint.sh: ignoring /docker-entrypoint-initdb.d/*

2025-12-22 22:49:02.192 UTC [46] LOG:  received fast shutdown request
waiting for server to shut down....2025-12-22 22:49:02.291 UTC [46] LOG:  aborting any active transactions
2025-12-22 22:49:02.304 UTC [46] LOG:  background worker "logical replication launcher" (PID 53) exited with exit code 1
2025-12-22 22:49:02.305 UTC [48] LOG:  shutting down
2025-12-22 22:49:02.780 UTC [46] LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

2025-12-22 22:49:03.072 UTC [1] LOG:  starting PostgreSQL 14.20 (Debian 14.20-1.pgdg13+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit
2025-12-22 22:49:03.075 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2025-12-22 22:49:03.075 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2025-12-22 22:49:03.306 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2025-12-22 22:49:03.508 UTC [61] LOG:  database system was shut down at 2025-12-22 22:49:02 UTC
2025-12-22 22:49:03.616 UTC [1] LOG:  database system is ready to accept connections
```

### central-webhook container:
```
{"time":"2025-12-22T22:48:38.604143091Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:48:38.608099042Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":1,"max_retries":30,"retry_in":1000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:48:39.610251472Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":2,"max_retries":30,"retry_in":2000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:48:41.612505246Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":3,"max_retries":30,"retry_in":4000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:48:45.616873697Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":4,"max_retries":30,"retry_in":5000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:48:50.621633905Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":5,"max_retries":30,"retry_in":5000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:48:55.627319474Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":6,"max_retries":30,"retry_in":5000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:49:00.63341253Z","level":"INFO","source":{"file":"connection.go","line":52},"msg":"Database ping failed, retrying","attempt":7,"max_retries":30,"retry_in":5000000000,"err":"failed to connect to `user=odk database=odk`: 192.168.16.8:5432 (postgres14): dial error: dial tcp 192.168.16.8:5432: connect: connection refused"}
{"time":"2025-12-22T22:49:05.686432918Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":8}
{"time":"2025-12-22T22:49:05.686519359Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:10.589865665Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:10.623011781Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:10.623114951Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:15.390639923Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:15.431321413Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:15.432555702Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:20.287948142Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:20.330598806Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:20.330726675Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:24.839720451Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:24.871443415Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:24.871840487Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:31.22739945Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:31.258159348Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:31.258235048Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:38.354639732Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:38.433852239Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:38.43400518Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:49:48.13068629Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:49:48.399048876Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:49:48.399206293Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:50:03.674482365Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:50:03.978298831Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:50:03.9783826Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
Error: failed to install triggers: table "audits" does not exist. This tool requires an ODK Central database with the "audits" table. Please verify you are connecting to the correct database and that ODK Central has been properly initialized
{"time":"2025-12-22T22:50:31.599381893Z","level":"INFO","source":{"file":"connection.go","line":31},"msg":"Connecting to database","max_retries":30}
{"time":"2025-12-22T22:50:31.634996208Z","level":"INFO","source":{"file":"connection.go","line":63},"msg":"Database connection established","attempts":1}
{"time":"2025-12-22T22:50:31.635077565Z","level":"INFO","source":{"file":"main.go","line":166},"msg":"Installing webhook triggers"}
{"time":"2025-12-22T22:50:32.151916742Z","level":"INFO","source":{"file":"main.go","line":177},"msg":"Webhook triggers installed successfully"}
```

Instead of `restart: always` I think it would be better to use `restart: on-failure`.

And about this connection failure in the beginning I don't know what is the best way to fix it. Maybe by letting `central-webhook` wait like 5 mins before doing the first connection?

I hope this is helpful.

